### PR TITLE
Travis Continous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,5 @@ before_install:
 
 install: python multisetup.py develop
 
-script:
-    - cd core
-    - nosetests
-    - cd ../vpltk
-    - nosetests
-    - cd ../oalab
-    - nosetests
-    - cd ../misc
-    - nosetests
-    
+script: nosetests -w core ../misc ../oalab ../vpltk   
 


### PR DESCRIPTION
This PR permit to automatically run Travis Continous Integration when a push is done on the repository (just need to switch on https://travis-ci.org/ ).

More information about travis configuration file: http://docs.travis-ci.com/user/build-configuration/#.travis.yml-file%3A-what-it-is-and-how-it-is-used
