### PR TITLE
Fix bug when renaming data

### DIFF
--- a/oalab/src/openalea/oalab/project/projectwidget.py
+++ b/oalab/src/openalea/oalab/project/projectwidget.py
@@ -500,8 +500,8 @@ class ProjectManagerView(QtGui.QTreeView):
 
     def _rename(self, project, category, name):
         if category in project.category_keys:
-            list_models = project.model.keys()
-            renamer = RenameModel(list_models, name)
+            filelist = getattr(project, category).keys()
+            renamer = RenameModel(filelist, name)
             dialog = ModalDialog(renamer)
             if dialog.exec_():
                 old_name = renamer.old_name()


### PR DESCRIPTION
If user want to rename a data from GUI, result was

  Traceback (most recent call last):
    File ".../oalab/src/openalea/oalab/project/projectwidget.py", line 516, in rename
      self._rename(project, category, name)
    File ".../oalab/src/openalea/oalab/project/projectwidget.py", line 504, in _rename
      renamer = RenameModel(list_models, name)
    File ".../oalab/src/openalea/oalab/project/projectwidget.py", line 100, in __init__
      self.combo.setCurrentIndex(self.models.index(model_name))
  ValueError: u'sample.jpg' is not in list

This pull request fix this issue
