### PR TITLE
Extend pygments with lpy lexer

### DIFF
--- a/oalab/setup.py
+++ b/oalab/setup.py
@@ -84,6 +84,7 @@ setup(
 
     # Declare src and wralea as entry_points (extensions) of your package
     entry_points={
+        'pygments.lexers': ['LPyLexer = openalea.oalab.editor.lpy_lexer:LPyLexer'],
 
         'gui_scripts': [
             'oalab = openalea.oalab.main:main',

--- a/oalab/test/test_lpy_lexer.py
+++ b/oalab/test/test_lpy_lexer.py
@@ -1,0 +1,24 @@
+# -*- python -*-
+#
+#       OpenAlea.OALab: Multi-Paradigm GUI
+#
+#       Copyright 2014 INRIA - CIRAD - INRA
+#
+#       File author(s): Julien Coste <julien.coste@inria.fr>
+#
+#       File contributor(s):
+#
+#       Distributed under the Cecill-C License.
+#       See accompanying file LICENSE.txt or copy at
+#           http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html
+#
+#       OpenAlea WebSite : http://openalea.gforge.inria.fr
+#
+###############################################################################
+from pygments.lexers import guess_lexer_for_filename
+
+
+def test_entry_point():
+    lexer = guess_lexer_for_filename('test.lpy', "")
+    assert lexer is not None
+    assert lexer.name is 'LPy'


### PR DESCRIPTION
I create an entry_point to declare lpy lexer. So we can use classical mecanism to guess lexer to use with pygments (cf. test).
