### PR TITLE
Change default drag and drop text for controls

### DIFF
--- a/oalab/src/openalea/oalab/gui/control/model_view.py
+++ b/oalab/src/openalea/oalab/gui/control/model_view.py
@@ -233,7 +233,7 @@ class ControlModel(QtGui.QStandardItemModel, AbstractListener):
         mimetype, mimedata = encode(control)
         qmime_data = QtCore.QMimeData()
         qmime_data.setData(mimetype, mimedata)
-        qmime_data.setText(mimedata)
+        qmime_data.setText(control.name)
         return qmime_data
 
     def data (self, index, role):


### PR DESCRIPTION
Before this patch, drag and drop of a control in shell dropped "id;name" like "140512335223984;i0".
Now, only control name (i0) is dropped in shell (and other widgets accepting text drop)
@pradal 
