### PR TITLE
Save node and composite node

### DIFF
--- a/core/src/core/compositenode.py
+++ b/core/src/core/compositenode.py
@@ -36,7 +36,7 @@ from openalea.core.settings import Settings
 from openalea.core.metadatadict import MetaDataDict
 import logger
 
-quantify = True
+quantify = False
 
 class IncompatibleNodeError(Exception):
     """todo"""

--- a/core/src/core/compositenode.py
+++ b/core/src/core/compositenode.py
@@ -1177,7 +1177,9 @@ $NAME = CompositeNodeFactory(name=$PNAME,
         f = self.factory
         fstr = string.Template(self.sgfactory_template)
 
-        result = fstr.safe_substitute(NAME=f.get_python_name(),
+        name = f.get_python_name()
+        name = name.replace('.', '_')
+        result = fstr.safe_substitute(NAME=name,
                                       PNAME=self.pprint_repr(f.name),
                                       DESCRIPTION=self.pprint_repr(f.description),
                                       CATEGORY=self.pprint_repr(f.category),

--- a/core/src/core/node.py
+++ b/core/src/core/node.py
@@ -1391,8 +1391,10 @@ $NAME = Factory(name=$PNAME,
         """ Return the python string representation """
         f = self.factory
         fstr = string.Template(self.nodefactory_template)
-
-        result = fstr.safe_substitute(NAME=f.get_python_name(),
+        
+        name = f.get_python_name()
+        name = name.replace('.', '_')
+        result = fstr.safe_substitute(NAME=name,
                                       AUTHORS=repr(f.get_authors()),
                                       PNAME=repr(f.name),
                                       DESCRIPTION=repr(f.description),


### PR DESCRIPTION
This branch fix the issue #137

Now node and composite node are valid Python string. 