### PR TITLE
Improve close event management.

### DIFF
--- a/oalab/src/openalea/oalab/main2.py
+++ b/oalab/src/openalea/oalab/main2.py
@@ -38,17 +38,12 @@ def launch_lab(plugin_class):
     OALabMainWin.LAB = lab_class
     if hasattr(lab_class, "start"):
         lab_class.start()
-    win = OALabMainWin()
+    win = OALabMainWin(lab=lab_class)
     if hasattr(lab_class, 'connect_applet'):
         win.appletSet.connect(lab_class.connect_applet)
     win.emit_applet_set()
-
     if hasattr(lab_class, "initialize"):
         lab_class.initialize()
-    if hasattr(lab_class, "finalize"):
-        win.aboutToClose.connect(lab_class.finalize)
-    if hasattr(lab_class, "stop"):
-        win.closed.connect(lab_class.stop)
     win.initialize()
     win.setWindowTitle('OpenAleaLab "%s"' % alias(plugin))
     win.showMaximized()

--- a/oalab/src/openalea/oalab/plugins/labs/minilab.py
+++ b/oalab/src/openalea/oalab/plugins/labs/minilab.py
@@ -36,7 +36,7 @@ def connect(old, new, sender_str, receiver_str, existing_connections):
 
 
 class MiniLab(object):
-
+    state = 'stopped'
     existing_connections = []  # list to store all created connections
     connections = []
 
@@ -186,16 +186,20 @@ class MiniLab(object):
 
     @classmethod
     def start(cls, *args, **kwds):
-        pass
+        cls.state = "started"
 
     @classmethod
     def initialize(cls, *args, **kwds):
-        pass
+        cls.state = "initialized"
+
+    @classmethod
+    def readytoclose(cls, *args, **kwds):
+        return True
 
     @classmethod
     def finalize(cls, *args, **kwds):
-        pass
+        cls.state = "finalized"
 
     @classmethod
     def stop(cls, *args, **kwds):
-        pass
+        cls.state = "stopped"

--- a/oalab/src/openalea/oalab/project/projectwidget.py
+++ b/oalab/src/openalea/oalab/project/projectwidget.py
@@ -163,8 +163,9 @@ class ProjectManagerWidget(QtGui.QWidget, AbstractListener):
         self.view.initialize()
         self.set_project(self.pm.cproject)
 
-    def close(self):
-        pass
+    def closeEvent(self, event):
+        self.writeSettings()
+        event.accept()
 
     def actions(self):
         return self._actions
@@ -233,6 +234,21 @@ class ProjectManagerWidget(QtGui.QWidget, AbstractListener):
 
     def set_project(self, project):
         self.view.set_project(project)
+
+    ####################################################################
+    # Settings
+    ####################################################################
+    def writeSettings(self):
+        """
+        Register current settings (geometry and window state)
+        in a setting file
+        """
+        if self.pm.cproject:
+            from openalea.core.settings import Settings
+            last_proj = self.pm.cproject.name
+            config = Settings()
+            config.set("ProjectManager", "Last Project", last_proj)
+            config.write()
 
 
 class ProjectManagerView(QtGui.QTreeView):


### PR DESCRIPTION
Now, applet can intercept closing thanks to closeEvent.
This allows ...
  - to stop closing (for example "a simulation is running, do you want to close application")
  - to do necessary before stopping.

First example:
  - ProjectWidget save last project in settings at closing