### PR TITLE
Allow user to define a transform for each viewer

### DIFF
--- a/oalab/share/data/getting_start/model/extend_viewer_support.py
+++ b/oalab/share/data/getting_start/model/extend_viewer_support.py
@@ -19,13 +19,16 @@ world['obj1'] = pgl_scene
 
 ################################################################################
 # 2. Object is not directly compatible but provides
-# a method (_repr_geom_) to convert himself to a compatible type 
+# a method (_repr_geom_) to convert himself to a compatible type
 # (Currently PlantGL geometry, shape or scene)
 ################################################################################
 
 # object type (generally defined in a separated module)
 from openalea.plantgl.all import Box
+
+
 class MyBox(object):
+
     def __init__(self, lx, ly, lz):
         self.lx = lx
         self.ly = ly
@@ -52,6 +55,8 @@ world['obj2'] = b
 
 # Define and register adapter. (generally defined in a separated plugin)
 from openalea.oalab.service.geometry import register_shape3d
+
+
 def to_shape3d(obj):
     if isinstance(obj, PlantFrame):
         return pf.plot(gc=True, display=False)
@@ -69,5 +74,6 @@ world['obj3'].repr = 'geom'
 
 world['i1'] = 1
 
+
 def init():
-  del world['i1'], world['obj1'], world['obj2'], world['obj3']
+    del world['i1'], world['obj1'], world['obj2'], world['obj3']

--- a/oalab/src/openalea/oalab/service/geometry.py
+++ b/oalab/src/openalea/oalab/service/geometry.py
@@ -9,6 +9,7 @@ from openalea.oalab.world.world import WorldObject
 
 __all__ = ['to_shape3d', 'register_shape3d']
 
+
 def find_plugins(plugin_name='oalab.service.to_shape3d', debug=False):
     """ Find plugins defined as entry points.
 
@@ -24,8 +25,10 @@ def find_plugins(plugin_name='oalab.service.to_shape3d', debug=False):
 
 __registry = find_plugins()
 
+
 def register_shape3d(type_or_types, functor):
     __registry[type_or_types] = functor
+
 
 def to_shape3d(obj):
     import openalea.plantgl.all as pgl


### PR DESCRIPTION
User can now specify how an object in the world is converted, depending on context.
Notation follows IPython conventions "_repr_html_".

For example, to set converter fonctions for
  - a vtk-compatible viewer
  - an html compatible viewer
user can write

```
world.add(data, _repr_vtk_=to_vtk_actor, _repr_html_=to_html)
```

with to_vtk_actor a function converting data to a vtkActor and 
to_html a function converting data to html string.

This functions was yet implemented but only for PlantGL.
This is a generalization of this approach.
