### PR TITLE
Restore syntax "exec in ns" compatible everywhere

### DIFF
--- a/core/src/core/interpreter/__init__.py
+++ b/core/src/core/interpreter/__init__.py
@@ -1,5 +1,6 @@
 
 from openalea.vpltk.check.ipython import has_ipython
+import sys
 
 
 def get_interpreter_class():
@@ -52,11 +53,10 @@ def adapt_interpreter(ip):
         :param source: text (string) to load
         :param namespace: dict to use to execute the source
         """
-        # Not multiligne
         if namespace is not None:
-            exec(source, namespace)
+            exec source in namespace
         else:
-            exec(source, self.locals, self.locals)
+            exec source in self.locals, self.locals
 
     def runsource(self, source=None, filename="<input>", symbol="single"):
         try:


### PR DESCRIPTION
exec(code, ns) is not compatible with python <= 2.7.6.
As this code raise a SyntaxError, it is not possible to use a version check to run "exec(code, ns)" or "exec code in ns"