### PR TITLE
Add a service to get implementation corresponding to a given plugin.

### DIFF
--- a/core/src/core/service/plugin.py
+++ b/core/src/core/service/plugin.py
@@ -104,7 +104,7 @@ class PluginInstanceManager(object):
             # Passed instance is not registered for this plugin
             pass
 
-    def _new(self, category, name, class_args=None, class_kwds=None):
+    def _function(self, category, name):
         if category not in self.pm._plugin:
             self.pm._load_plugins(category)
         try:
@@ -117,21 +117,21 @@ class PluginInstanceManager(object):
             except TypeError, e:
                 raise enhanced_error(e, plugin_class=plugin_class)
 
-            if class_args is None:
-                class_args = []
-            if class_kwds is None:
-                class_kwds = {}
-
             try:
-                klass = plugin()
+                function = plugin()
             except TypeError, e:
                 raise enhanced_error(e, plugin=plugin, plugin_class=plugin_class)
+
+            return function
+
+    def function(self, category, name):
+        if self._debug_mode(category):
+            return self._function(category, name)
+        else:
             try:
-                instance = klass(*class_args, **class_kwds)
-            except TypeError, e:
-                raise enhanced_error(e, plugin_class=klass)
-            self.register(category, name, instance)
-            return instance
+                return self._function(category, name)
+            except:
+                return None
 
     def new(self, category, name, class_args=None, class_kwds=None):
         """
@@ -218,5 +218,6 @@ debug_plugin = PIM.__call__
 new_plugin_instance = PIM.new
 plugin_implementations = PIM.implementations
 plugin_instance = PIM.instance
+plugin_function = PIM.function
 plugin_instances = PIM.instances
 plugin_instance_exists = PIM.has_instance

--- a/oalab/src/openalea/oalab/cli/parser.py
+++ b/oalab/src/openalea/oalab/cli/parser.py
@@ -68,23 +68,26 @@ class CommandLineParser(object):
             from openalea.core.plugin import iter_groups
 
             if args.list_plugins in ['summary', 'all']:
-                for category in sorted(iter_groups()):
-                    if category.startswith('oalab') or category.startswith('vpltk'):
-                        eps = [ep for ep in pkg_resources.iter_entry_points(category)]
-                        if args.list_plugins == 'all':
-                            print '\033[91m%s\033[0m' % category
-                            print
-                            for ep in eps:
-                                print_plugin_name(ep)
-                            print
-                            print
-                        else:
-                            print '  - \033[91m%s\033[0m (%d plugins)' % (category, len(eps))
-
-            elif args.list_plugins:
-                print 'Plugins for category %r' % args.list_plugins
-                for ep in pkg_resources.iter_entry_points(args.list_plugins):
-                    print_plugin_name(ep)
+                prefixes = ['oalab', 'vpltk', 'openalea']
+            else:
+                prefixes = [args.list_plugins]
+            for category in sorted(iter_groups()):
+                match = False
+                for prefix in prefixes:
+                    if category.startswith(prefix):
+                        match = True
+                        break
+                if match:
+                    eps = [ep for ep in pkg_resources.iter_entry_points(category)]
+                    if args.list_plugins == 'summary':
+                        print '  - \033[91m%s\033[0m (%d plugins)' % (category, len(eps))
+                    else:
+                        print '\033[91m%s\033[0m' % category
+                        print
+                        for ep in eps:
+                            print_plugin_name(ep)
+                        print
+                        print
 
         if args.debug_plugins:
             debug = args.debug_plugins.split(',')


### PR DESCRIPTION
For example plugin_function('openalea.image.filtering', 'gaussian_smoothing') returns corresponding function

oalab --list-plugins=prefix search for all plugins starting with prefix instead of matching exactly prefix