### PR TITLE
fix #171 bug

### DIFF
--- a/core/src/core/interpreter/ipython.py
+++ b/core/src/core/interpreter/ipython.py
@@ -32,6 +32,8 @@ class IPythonInProcessInterpreter(InProcessKernel):
     :param gui: GUI to use. Default 'qt4'.
     :param locals: namespace to set to the interpreter. Default 'None'.
     """
+    # NOTE: to manually define class used for shell, for example InProcessInteractiveShell, just set shell_class attr
+    # shell_class = InProcessInteractiveShell
 
     def __init__(self, gui="qt4", locals=None):
         super(IPythonInProcessInterpreter, self).__init__(gui=gui)

--- a/core/src/core/project/project.py
+++ b/core/src/core/project/project.py
@@ -218,7 +218,8 @@ class Project(Observed):
             self.ns.update(ns)
         shell = kwargs.get('shell')
         if shell:
-            shell.user_ns = self.ns
+            shell.user_ns.clear()
+            shell.user_ns.update(self.ns)
 
     def stop(self, *args, **kwargs):
         self.started = False

--- a/core/test/test_model.py
+++ b/core/test/test_model.py
@@ -287,7 +287,7 @@ out = f()
     from openalea.core.model import PythonModel
     model = PythonModel(name='func')
     model.set_code(code)
-    model.init()
-    model.step()
+    assert model.init() == 1
 
-test_in_function()
+
+


### PR DESCRIPTION
As user_ns was redefined in Project.start, user_ns and global_ns were no more linked and so, global_variables were ignored.