### PR TITLE
Swap position of misc and core in multisetup.py

### DIFF
--- a/multisetup.py
+++ b/multisetup.py
@@ -47,8 +47,8 @@ except ImportError:
 
 dirs = """
 vpltk
-core
 misc
+core
 grapheditor
 visualea
 oalab


### PR DESCRIPTION
Misc is needed in core for building sphinx, for instance.
So I move up misc before core.